### PR TITLE
Fix minimum flashcard count

### DIFF
--- a/main.py
+++ b/main.py
@@ -266,7 +266,8 @@ def calc_num_questions(num_tokens):
     Returns:
         int: The number of questions to generate.
     """
-    return round(math.sqrt(num_tokens) / 25)
+    num_questions = round(math.sqrt(num_tokens) / 25)
+    return max(1, num_questions)
 
 
 def generate_flashcards(text, language="english", custom_num_questions=None):


### PR DESCRIPTION
## Summary
- ensure `calc_num_questions` never returns 0

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pyflakes $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f4ab5411c8332a98e54fb0729f533